### PR TITLE
Add dryrun and summary capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ keys.js
 .DS_Store
 node_modules/
 assets-*/
+summary-*.json

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The `timeZone` value is used for converting incident times (Citizen stores them 
 ---
 
 ### Advanced
+#### Dry Run
+Use the `--dryRun` flag to print all tweets to the console instead of posting on Twitter.
+
 #### Satellite image of crash site
 The bot can tweet zoomed in satellite images of the crash site, in addition to the standard citizen map. To enable this, you'll first need to add a `googleKey` property to your city object in the `keys.js` file containing an API key from a [Google Developer Platform account](https://developers.google.com/maps/documentation/maps-static/get-api-key). Example:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ The `timeZone` value is used for converting incident times (Citizen stores them 
 ---
 
 ### Advanced
+#### Weekly and monthly summary
+The bot can tweet weekly and monthly summaries of the number of incidents it reported, on the last day of the week and month. Use the `--summary` flag when running the bot. It will create a `summary-cityName.json` file it will use to keep track of these numbers and report.
+
 #### Dry Run
 Use the `--dryRun` flag to print all tweets to the console instead of posting on Twitter.
 

--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ const tweetIncidentThread = async (client, incident) => {
         tweets.push(`This incident occurred in ${representatives[argv.location].repesentativeDistrictTerm} ${incident.cityCouncilDistrict}. \n\nRepresentative: ${representative}`)
     }
 
-    tweetThread(tweets);
+    tweetThread(client, tweets);
 };
 
 /**
@@ -187,7 +187,7 @@ const tweetSummaryOfLast24Hours = async (client, incidents) => {
         }
     }
 
-    tweetThread(tweets);
+    tweetThread(client, tweets);
 };
 
 /**
@@ -284,7 +284,7 @@ const validateInputs = () => {
     }
 };
 
-const tweetThread = async (tweets) => {
+const tweetThread = async (client, tweets) => {
     if (argv.dryRun) {
         console.log(tweets)
     } else {
@@ -294,7 +294,7 @@ const tweetThread = async (tweets) => {
 
 const isLastDayOfMonth = (dateTime) => new Date(dateTime.getTime() + 86400000).getDate() === 1;
 
-const handleSummary = async (incidents) => {
+const handleSummary = async (client, incidents) => {
     await fs.ensureFileSync(summaryFile);
 
     const tweets = [];
@@ -338,7 +338,7 @@ const handleSummary = async (incidents) => {
     if (tweets.length > 0) {
         tweets.push(disclaimerTweet);
         
-        tweetThread(tweets);
+        tweetThread(client, tweets);
     }
 
     await fs.writeFileSync(summaryFile, JSON.stringify(summary));
@@ -379,7 +379,7 @@ const main = async () => {
 
     if (argv.summary) {
         await delay(delayTime);
-        handleSummary(filteredIncidents);
+        handleSummary(client, filteredIncidents);
     }
 };
 


### PR DESCRIPTION
This PR adds two things:
* Dryrun ability. Run the bot with the `--dryRun` flag, and the bot will print all tweets to the console instead of posting to Twitter. This is useful for debugging and working on new features.
* Weekly and monthly crash tracking. When run with the `--summary` flag, the bot will keep track of the weekly and monthly crashes it reports, and tweets those number on the last day of the week and month.